### PR TITLE
Fix grammar for empty pokemons message

### DIFF
--- a/src/widgets/pokemons-grid/ui/PokemonsGrid.tsx
+++ b/src/widgets/pokemons-grid/ui/PokemonsGrid.tsx
@@ -26,7 +26,7 @@ export const PokemonsGrid: React.FC = () => {
     return <List
         grid={{gutter: 16, column: 4, xs: 1, sm: 1, md: 2, lg: 3, xl: 4, xxl: 4}}
         dataSource={pokemons}
-        locale={{emptyText: <Empty description={`There are no any pokemons.`} />}}
+        locale={{emptyText: <Empty description={`There are no pokemons.`} />}}
         loading={{spinning: isFetching, tip: 'Loading pokemons...'}}
         pagination={{
             onChange: onPageChange,


### PR DESCRIPTION
## Summary
- fix the grammar of the empty list message

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68408e3fb8ec8323ba9c76e3ef9cd743